### PR TITLE
Fix file descriptor leak issue

### DIFF
--- a/types.go
+++ b/types.go
@@ -371,25 +371,30 @@ func (n *AbsfsNFS) ExecuteWithWorker(task func() interface{}) interface{} {
 func (n *AbsfsNFS) Close() error {
 	// Stop memory monitoring if active
 	n.stopMemoryMonitoring()
-	
+
 	// Stop worker pool
 	if n.workerPool != nil {
 		n.workerPool.Stop()
 	}
-	
+
 	// Stop batch processor
 	if n.batchProc != nil {
 		n.batchProc.Stop()
 	}
-	
+
+	// Release all file handles to prevent file descriptor leaks
+	if n.fileMap != nil {
+		n.fileMap.ReleaseAll()
+	}
+
 	// Clear caches to free memory
 	if n.attrCache != nil {
 		n.attrCache.Clear()
 	}
-	
+
 	if n.readBuf != nil {
 		n.readBuf.Clear()
 	}
-	
+
 	return nil
 }


### PR DESCRIPTION
The Close() method was not releasing file handles from the fileMap, causing file descriptors to leak when the server was closed without first calling Unexport(). This fix adds a call to fileMap.ReleaseAll() in the Close() method to properly release all file handles and prevent the leak.

The Unexport() method already had this cleanup, but Close() did not, which meant that any direct calls to Close() would leave file handles open.

Fixes #7