### PR TITLE
Implement authentication enforcement for issue #8

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,141 @@
+package absnfs
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// AuthContext contains information about the client making a request
+type AuthContext struct {
+	ClientIP   string            // Client IP address
+	ClientPort int               // Client port number
+	Credential *RPCCredential    // RPC credential
+	AuthSys    *AuthSysCredential // Parsed AUTH_SYS credential (if applicable)
+}
+
+// AuthResult contains the result of authentication validation
+type AuthResult struct {
+	Allowed bool   // Whether the request is allowed
+	UID     uint32 // Effective UID after squashing
+	GID     uint32 // Effective GID after squashing
+	Reason  string // Reason for denial (if not allowed)
+}
+
+// ValidateAuthentication validates a client request against export options
+func ValidateAuthentication(ctx *AuthContext, options ExportOptions) *AuthResult {
+	result := &AuthResult{
+		Allowed: false,
+		UID:     65534, // Default to nobody
+		GID:     65534, // Default to nobody
+	}
+
+	// Step 1: Validate client IP address
+	if len(options.AllowedIPs) > 0 {
+		if !isIPAllowed(ctx.ClientIP, options.AllowedIPs) {
+			result.Reason = fmt.Sprintf("client IP %s not in allowed list", ctx.ClientIP)
+			return result
+		}
+	}
+
+	// Step 2: Validate secure port requirement
+	if options.Secure {
+		if ctx.ClientPort >= 1024 {
+			result.Reason = fmt.Sprintf("client port %d is not a privileged port (required when Secure=true)", ctx.ClientPort)
+			return result
+		}
+	}
+
+	// Step 3: Validate credential flavor
+	switch ctx.Credential.Flavor {
+	case AUTH_NONE:
+		// AUTH_NONE is always accepted but uses nobody/nobody
+		result.Allowed = true
+		result.UID = 65534
+		result.GID = 65534
+
+	case AUTH_SYS:
+		// Parse AUTH_SYS credentials if not already parsed
+		if ctx.AuthSys == nil {
+			authSys, err := ParseAuthSysCredential(ctx.Credential.Body)
+			if err != nil {
+				result.Reason = fmt.Sprintf("invalid AUTH_SYS credentials: %v", err)
+				return result
+			}
+			ctx.AuthSys = authSys
+		}
+
+		// AUTH_SYS is accepted
+		result.Allowed = true
+		result.UID = ctx.AuthSys.UID
+		result.GID = ctx.AuthSys.GID
+
+		// Step 4: Apply squashing (user mapping)
+		applySquashing(result, ctx.AuthSys, options.Squash)
+
+	default:
+		// Other authentication flavors are not supported
+		result.Reason = fmt.Sprintf("unsupported authentication flavor: %d", ctx.Credential.Flavor)
+		return result
+	}
+
+	return result
+}
+
+// applySquashing applies user ID squashing/mapping according to the export options
+func applySquashing(result *AuthResult, authSys *AuthSysCredential, squash string) {
+	switch strings.ToLower(squash) {
+	case "root":
+		// Map root (UID 0) to nobody
+		if authSys.UID == 0 {
+			result.UID = 65534
+		}
+		if authSys.GID == 0 {
+			result.GID = 65534
+		}
+
+	case "all":
+		// Map all users to nobody
+		result.UID = 65534
+		result.GID = 65534
+
+	case "none", "":
+		// No squashing - use the credentials as provided
+		// (already set in result)
+
+	default:
+		// Unknown squash mode - default to no squashing
+		// Could log a warning here in the future
+	}
+}
+
+// isIPAllowed checks if a client IP is in the allowed list
+func isIPAllowed(clientIP string, allowedIPs []string) bool {
+	// Parse client IP
+	ip := net.ParseIP(clientIP)
+	if ip == nil {
+		return false
+	}
+
+	// Check against each allowed IP/subnet
+	for _, allowed := range allowedIPs {
+		// Check if it's a CIDR notation
+		if strings.Contains(allowed, "/") {
+			_, subnet, err := net.ParseCIDR(allowed)
+			if err != nil {
+				continue // Invalid CIDR, skip
+			}
+			if subnet.Contains(ip) {
+				return true
+			}
+		} else {
+			// Direct IP comparison
+			allowedIP := net.ParseIP(allowed)
+			if allowedIP != nil && allowedIP.Equal(ip) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,464 @@
+package absnfs
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/absfs/memfs"
+)
+
+func TestAuthenticationEnforcement(t *testing.T) {
+	t.Run("AUTH_NONE is allowed", func(t *testing.T) {
+		memfs, err := memfs.NewFS()
+		if err != nil {
+			t.Fatalf("Failed to create memfs: %v", err)
+		}
+
+		fs, err := New(memfs, ExportOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create NFS: %v", err)
+		}
+
+		handler := &NFSProcedureHandler{
+			server: &Server{
+				handler: fs,
+				options: ServerOptions{Debug: false},
+			},
+		}
+
+		call := &RPCCall{
+			Header: RPCMsgHeader{
+				Xid:        1,
+				MsgType:    RPC_CALL,
+				RPCVersion: 2,
+				Program:    NFS_PROGRAM,
+				Version:    NFS_V3,
+				Procedure:  NFSPROC3_NULL,
+			},
+			Credential: RPCCredential{
+				Flavor: AUTH_NONE,
+				Body:   []byte{},
+			},
+		}
+
+		authCtx := &AuthContext{
+			ClientIP:   "127.0.0.1",
+			ClientPort: 1023,
+			Credential: &call.Credential,
+		}
+
+		reply, err := handler.HandleCall(call, bytes.NewReader([]byte{}), authCtx)
+		if err != nil {
+			t.Fatalf("HandleCall failed: %v", err)
+		}
+		if reply.Status != MSG_ACCEPTED {
+			t.Errorf("Expected MSG_ACCEPTED for AUTH_NONE, got %v", reply.Status)
+		}
+	})
+
+	t.Run("AUTH_SYS is allowed", func(t *testing.T) {
+		memfs, err := memfs.NewFS()
+		if err != nil {
+			t.Fatalf("Failed to create memfs: %v", err)
+		}
+
+		fs, err := New(memfs, ExportOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create NFS: %v", err)
+		}
+
+		handler := &NFSProcedureHandler{
+			server: &Server{
+				handler: fs,
+				options: ServerOptions{Debug: false},
+			},
+		}
+
+		// Create a valid AUTH_SYS credential
+		var credBody bytes.Buffer
+		binary.Write(&credBody, binary.BigEndian, uint32(12345))      // Stamp
+		binary.Write(&credBody, binary.BigEndian, uint32(0))          // Machine name length (empty)
+		binary.Write(&credBody, binary.BigEndian, uint32(1000))       // UID
+		binary.Write(&credBody, binary.BigEndian, uint32(1000))       // GID
+		binary.Write(&credBody, binary.BigEndian, uint32(0))          // Number of auxiliary GIDs
+
+		call := &RPCCall{
+			Header: RPCMsgHeader{
+				Xid:        1,
+				MsgType:    RPC_CALL,
+				RPCVersion: 2,
+				Program:    NFS_PROGRAM,
+				Version:    NFS_V3,
+				Procedure:  NFSPROC3_NULL,
+			},
+			Credential: RPCCredential{
+				Flavor: AUTH_SYS,
+				Body:   credBody.Bytes(),
+			},
+		}
+
+		authCtx := &AuthContext{
+			ClientIP:   "127.0.0.1",
+			ClientPort: 1023,
+			Credential: &call.Credential,
+		}
+
+		reply, err := handler.HandleCall(call, bytes.NewReader([]byte{}), authCtx)
+		if err != nil {
+			t.Fatalf("HandleCall failed: %v", err)
+		}
+		if reply.Status != MSG_ACCEPTED {
+			t.Errorf("Expected MSG_ACCEPTED for AUTH_SYS, got %v", reply.Status)
+		}
+	})
+
+	t.Run("IP restriction enforced", func(t *testing.T) {
+		memfs, err := memfs.NewFS()
+		if err != nil {
+			t.Fatalf("Failed to create memfs: %v", err)
+		}
+
+		// Configure with IP restrictions
+		fs, err := New(memfs, ExportOptions{
+			AllowedIPs: []string{"192.168.1.0/24"},
+		})
+		if err != nil {
+			t.Fatalf("Failed to create NFS: %v", err)
+		}
+
+		handler := &NFSProcedureHandler{
+			server: &Server{
+				handler: fs,
+				options: ServerOptions{Debug: false},
+			},
+		}
+
+		call := &RPCCall{
+			Header: RPCMsgHeader{
+				Xid:        1,
+				MsgType:    RPC_CALL,
+				RPCVersion: 2,
+				Program:    NFS_PROGRAM,
+				Version:    NFS_V3,
+				Procedure:  NFSPROC3_NULL,
+			},
+			Credential: RPCCredential{
+				Flavor: AUTH_NONE,
+				Body:   []byte{},
+			},
+		}
+
+		// Client from disallowed IP
+		authCtx := &AuthContext{
+			ClientIP:   "10.0.0.1",
+			ClientPort: 1023,
+			Credential: &call.Credential,
+		}
+
+		reply, err := handler.HandleCall(call, bytes.NewReader([]byte{}), authCtx)
+		if err != nil {
+			t.Fatalf("HandleCall failed: %v", err)
+		}
+		if reply.Status != MSG_DENIED {
+			t.Errorf("Expected MSG_DENIED for disallowed IP, got %v", reply.Status)
+		}
+
+		// Client from allowed IP
+		authCtx.ClientIP = "192.168.1.100"
+		reply, err = handler.HandleCall(call, bytes.NewReader([]byte{}), authCtx)
+		if err != nil {
+			t.Fatalf("HandleCall failed: %v", err)
+		}
+		if reply.Status != MSG_ACCEPTED {
+			t.Errorf("Expected MSG_ACCEPTED for allowed IP, got %v", reply.Status)
+		}
+	})
+
+	t.Run("Secure port requirement enforced", func(t *testing.T) {
+		memfs, err := memfs.NewFS()
+		if err != nil {
+			t.Fatalf("Failed to create memfs: %v", err)
+		}
+
+		// Configure with Secure flag
+		fs, err := New(memfs, ExportOptions{
+			Secure: true,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create NFS: %v", err)
+		}
+
+		handler := &NFSProcedureHandler{
+			server: &Server{
+				handler: fs,
+				options: ServerOptions{Debug: false},
+			},
+		}
+
+		call := &RPCCall{
+			Header: RPCMsgHeader{
+				Xid:        1,
+				MsgType:    RPC_CALL,
+				RPCVersion: 2,
+				Program:    NFS_PROGRAM,
+				Version:    NFS_V3,
+				Procedure:  NFSPROC3_NULL,
+			},
+			Credential: RPCCredential{
+				Flavor: AUTH_NONE,
+				Body:   []byte{},
+			},
+		}
+
+		// Client from non-privileged port
+		authCtx := &AuthContext{
+			ClientIP:   "127.0.0.1",
+			ClientPort: 5000,
+			Credential: &call.Credential,
+		}
+
+		reply, err := handler.HandleCall(call, bytes.NewReader([]byte{}), authCtx)
+		if err != nil {
+			t.Fatalf("HandleCall failed: %v", err)
+		}
+		if reply.Status != MSG_DENIED {
+			t.Errorf("Expected MSG_DENIED for non-privileged port, got %v", reply.Status)
+		}
+
+		// Client from privileged port
+		authCtx.ClientPort = 1023
+		reply, err = handler.HandleCall(call, bytes.NewReader([]byte{}), authCtx)
+		if err != nil {
+			t.Fatalf("HandleCall failed: %v", err)
+		}
+		if reply.Status != MSG_ACCEPTED {
+			t.Errorf("Expected MSG_ACCEPTED for privileged port, got %v", reply.Status)
+		}
+	})
+
+	t.Run("Root squashing applied", func(t *testing.T) {
+		memfs, err := memfs.NewFS()
+		if err != nil {
+			t.Fatalf("Failed to create memfs: %v", err)
+		}
+
+		// Configure with root squashing
+		fs, err := New(memfs, ExportOptions{
+			Squash: "root",
+		})
+		if err != nil {
+			t.Fatalf("Failed to create NFS: %v", err)
+		}
+
+		// Create AUTH_SYS credential with UID=0 (root)
+		var credBody bytes.Buffer
+		binary.Write(&credBody, binary.BigEndian, uint32(12345))      // Stamp
+		binary.Write(&credBody, binary.BigEndian, uint32(0))          // Machine name length
+		binary.Write(&credBody, binary.BigEndian, uint32(0))          // UID = 0 (root)
+		binary.Write(&credBody, binary.BigEndian, uint32(0))          // GID = 0
+		binary.Write(&credBody, binary.BigEndian, uint32(0))          // No aux GIDs
+
+		call := &RPCCall{
+			Header: RPCMsgHeader{
+				Xid:        1,
+				MsgType:    RPC_CALL,
+				RPCVersion: 2,
+				Program:    NFS_PROGRAM,
+				Version:    NFS_V3,
+				Procedure:  NFSPROC3_NULL,
+			},
+			Credential: RPCCredential{
+				Flavor: AUTH_SYS,
+				Body:   credBody.Bytes(),
+			},
+		}
+
+		authCtx := &AuthContext{
+			ClientIP:   "127.0.0.1",
+			ClientPort: 1023,
+			Credential: &call.Credential,
+		}
+
+		// Validate authentication
+		authResult := ValidateAuthentication(authCtx, fs.options)
+
+		if !authResult.Allowed {
+			t.Errorf("Expected authentication to be allowed")
+		}
+
+		// Verify that root (UID 0) was mapped to nobody (UID 65534)
+		if authResult.UID != 65534 {
+			t.Errorf("Expected UID to be squashed to 65534, got %d", authResult.UID)
+		}
+		if authResult.GID != 65534 {
+			t.Errorf("Expected GID to be squashed to 65534, got %d", authResult.GID)
+		}
+	})
+
+	t.Run("All squashing applied", func(t *testing.T) {
+		memfs, err := memfs.NewFS()
+		if err != nil {
+			t.Fatalf("Failed to create memfs: %v", err)
+		}
+
+		// Configure with all squashing
+		fs, err := New(memfs, ExportOptions{
+			Squash: "all",
+		})
+		if err != nil {
+			t.Fatalf("Failed to create NFS: %v", err)
+		}
+
+		// Create AUTH_SYS credential with UID=1000 (non-root)
+		var credBody bytes.Buffer
+		binary.Write(&credBody, binary.BigEndian, uint32(12345))      // Stamp
+		binary.Write(&credBody, binary.BigEndian, uint32(0))          // Machine name length
+		binary.Write(&credBody, binary.BigEndian, uint32(1000))       // UID = 1000
+		binary.Write(&credBody, binary.BigEndian, uint32(1000))       // GID = 1000
+		binary.Write(&credBody, binary.BigEndian, uint32(0))          // No aux GIDs
+
+		authCtx := &AuthContext{
+			ClientIP:   "127.0.0.1",
+			ClientPort: 1023,
+			Credential: &RPCCredential{
+				Flavor: AUTH_SYS,
+				Body:   credBody.Bytes(),
+			},
+		}
+
+		// Validate authentication
+		authResult := ValidateAuthentication(authCtx, fs.options)
+
+		if !authResult.Allowed {
+			t.Errorf("Expected authentication to be allowed")
+		}
+
+		// Verify that non-root user was also mapped to nobody
+		if authResult.UID != 65534 {
+			t.Errorf("Expected UID to be squashed to 65534, got %d", authResult.UID)
+		}
+		if authResult.GID != 65534 {
+			t.Errorf("Expected GID to be squashed to 65534, got %d", authResult.GID)
+		}
+	})
+}
+
+func TestParseAuthSysCredential(t *testing.T) {
+	t.Run("Valid AUTH_SYS credential", func(t *testing.T) {
+		var buf bytes.Buffer
+		binary.Write(&buf, binary.BigEndian, uint32(12345))             // Stamp
+		binary.Write(&buf, binary.BigEndian, uint32(7))                 // Machine name length
+		buf.Write([]byte("testbox"))                                    // Machine name
+		buf.Write([]byte{0})                                            // Padding
+		binary.Write(&buf, binary.BigEndian, uint32(1000))              // UID
+		binary.Write(&buf, binary.BigEndian, uint32(1000))              // GID
+		binary.Write(&buf, binary.BigEndian, uint32(2))                 // Aux GID count
+		binary.Write(&buf, binary.BigEndian, uint32(1001))              // Aux GID 1
+		binary.Write(&buf, binary.BigEndian, uint32(1002))              // Aux GID 2
+
+		cred, err := ParseAuthSysCredential(buf.Bytes())
+		if err != nil {
+			t.Fatalf("Failed to parse AUTH_SYS credential: %v", err)
+		}
+
+		if cred.Stamp != 12345 {
+			t.Errorf("Expected stamp 12345, got %d", cred.Stamp)
+		}
+		if cred.MachineName != "testbox" {
+			t.Errorf("Expected machine name 'testbox', got '%s'", cred.MachineName)
+		}
+		if cred.UID != 1000 {
+			t.Errorf("Expected UID 1000, got %d", cred.UID)
+		}
+		if cred.GID != 1000 {
+			t.Errorf("Expected GID 1000, got %d", cred.GID)
+		}
+		if len(cred.AuxGIDs) != 2 {
+			t.Errorf("Expected 2 auxiliary GIDs, got %d", len(cred.AuxGIDs))
+		}
+		if len(cred.AuxGIDs) > 0 && cred.AuxGIDs[0] != 1001 {
+			t.Errorf("Expected aux GID[0] 1001, got %d", cred.AuxGIDs[0])
+		}
+		if len(cred.AuxGIDs) > 1 && cred.AuxGIDs[1] != 1002 {
+			t.Errorf("Expected aux GID[1] 1002, got %d", cred.AuxGIDs[1])
+		}
+	})
+
+	t.Run("Empty credential body", func(t *testing.T) {
+		_, err := ParseAuthSysCredential([]byte{})
+		if err == nil {
+			t.Error("Expected error for empty credential body")
+		}
+	})
+
+	t.Run("Too many auxiliary GIDs", func(t *testing.T) {
+		var buf bytes.Buffer
+		binary.Write(&buf, binary.BigEndian, uint32(12345))   // Stamp
+		binary.Write(&buf, binary.BigEndian, uint32(0))       // Machine name length
+		binary.Write(&buf, binary.BigEndian, uint32(1000))    // UID
+		binary.Write(&buf, binary.BigEndian, uint32(1000))    // GID
+		binary.Write(&buf, binary.BigEndian, uint32(100))     // Too many aux GIDs
+
+		_, err := ParseAuthSysCredential(buf.Bytes())
+		if err == nil {
+			t.Error("Expected error for too many auxiliary GIDs")
+		}
+	})
+}
+
+func TestIsIPAllowed(t *testing.T) {
+	tests := []struct {
+		name       string
+		clientIP   string
+		allowedIPs []string
+		expected   bool
+	}{
+		{
+			name:       "Exact IP match",
+			clientIP:   "192.168.1.100",
+			allowedIPs: []string{"192.168.1.100"},
+			expected:   true,
+		},
+		{
+			name:       "CIDR match",
+			clientIP:   "192.168.1.100",
+			allowedIPs: []string{"192.168.1.0/24"},
+			expected:   true,
+		},
+		{
+			name:       "Multiple IPs - match second",
+			clientIP:   "10.0.0.5",
+			allowedIPs: []string{"192.168.1.0/24", "10.0.0.0/8"},
+			expected:   true,
+		},
+		{
+			name:       "No match",
+			clientIP:   "172.16.0.1",
+			allowedIPs: []string{"192.168.1.0/24", "10.0.0.0/8"},
+			expected:   false,
+		},
+		{
+			name:       "IPv6 match",
+			clientIP:   "::1",
+			allowedIPs: []string{"::1"},
+			expected:   true,
+		},
+		{
+			name:       "Invalid IP",
+			clientIP:   "invalid",
+			allowedIPs: []string{"192.168.1.0/24"},
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isIPAllowed(tt.clientIP, tt.allowedIPs)
+			if result != tt.expected {
+				t.Errorf("isIPAllowed(%s, %v) = %v, expected %v",
+					tt.clientIP, tt.allowedIPs, result, tt.expected)
+			}
+		})
+	}
+}

--- a/rpc_types.go
+++ b/rpc_types.go
@@ -12,6 +12,14 @@ const (
 	RPC_REPLY = 1
 )
 
+// RPC authentication flavors (RFC 1831)
+const (
+	AUTH_NONE  = 0 // No authentication
+	AUTH_SYS   = 1 // UNIX-style authentication (formerly AUTH_UNIX)
+	AUTH_SHORT = 2 // Short hand UNIX-style
+	AUTH_DH    = 3 // Diffie-Hellman authentication
+)
+
 // Maximum sizes for XDR data structures to prevent DoS attacks
 const (
 	// MAX_XDR_STRING_LENGTH is the maximum allowed length for XDR strings (8KB)
@@ -139,6 +147,15 @@ type RPCCredential struct {
 type RPCVerifier struct {
 	Flavor uint32
 	Body   []byte
+}
+
+// AuthSysCredential represents AUTH_SYS credentials (RFC 1831)
+type AuthSysCredential struct {
+	Stamp      uint32   // Arbitrary ID which the client may generate
+	MachineName string  // Name of the client machine (or empty string)
+	UID        uint32   // Caller's effective user ID
+	GID        uint32   // Caller's effective group ID
+	AuxGIDs    []uint32 // Auxiliary group IDs
 }
 
 // RPCReply represents an RPC reply message
@@ -272,4 +289,99 @@ func EncodeRPCReply(w io.Writer, reply *RPCReply) error {
 	}
 
 	return nil
+}
+
+// ParseAuthSysCredential parses AUTH_SYS credential data from raw bytes
+func ParseAuthSysCredential(body []byte) (*AuthSysCredential, error) {
+	if len(body) == 0 {
+		return nil, fmt.Errorf("empty AUTH_SYS credential body")
+	}
+
+	r := &byteReader{data: body, pos: 0}
+	cred := &AuthSysCredential{}
+
+	// Read stamp (4 bytes)
+	var err error
+	cred.Stamp, err = r.readUint32()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read stamp: %v", err)
+	}
+
+	// Read machine name
+	cred.MachineName, err = r.readString()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read machine name: %v", err)
+	}
+
+	// Read UID
+	cred.UID, err = r.readUint32()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read UID: %v", err)
+	}
+
+	// Read GID
+	cred.GID, err = r.readUint32()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read GID: %v", err)
+	}
+
+	// Read auxiliary GIDs count
+	gidCount, err := r.readUint32()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read GID count: %v", err)
+	}
+
+	// Validate GID count to prevent DoS
+	if gidCount > 16 {
+		return nil, fmt.Errorf("too many auxiliary GIDs: %d (max 16)", gidCount)
+	}
+
+	// Read auxiliary GIDs
+	cred.AuxGIDs = make([]uint32, gidCount)
+	for i := uint32(0); i < gidCount; i++ {
+		cred.AuxGIDs[i], err = r.readUint32()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read auxiliary GID %d: %v", i, err)
+		}
+	}
+
+	return cred, nil
+}
+
+// byteReader is a simple helper for reading XDR-encoded data from a byte slice
+type byteReader struct {
+	data []byte
+	pos  int
+}
+
+func (r *byteReader) readUint32() (uint32, error) {
+	if r.pos+4 > len(r.data) {
+		return 0, fmt.Errorf("not enough data for uint32")
+	}
+	val := binary.BigEndian.Uint32(r.data[r.pos : r.pos+4])
+	r.pos += 4
+	return val, nil
+}
+
+func (r *byteReader) readString() (string, error) {
+	length, err := r.readUint32()
+	if err != nil {
+		return "", err
+	}
+
+	// Validate length
+	if length > MAX_XDR_STRING_LENGTH {
+		return "", fmt.Errorf("string length %d exceeds maximum %d", length, MAX_XDR_STRING_LENGTH)
+	}
+
+	// Calculate padded length (XDR strings are padded to 4-byte boundaries)
+	paddedLength := (length + 3) &^ 3
+
+	if r.pos+int(paddedLength) > len(r.data) {
+		return "", fmt.Errorf("not enough data for string")
+	}
+
+	str := string(r.data[r.pos : r.pos+int(length)])
+	r.pos += int(paddedLength)
+	return str, nil
 }


### PR DESCRIPTION
This commit addresses issue #8 by implementing proper authentication validation and enforcement mechanisms throughout the NFS server.

Changes:
- Add AUTH constants (AUTH_NONE, AUTH_SYS, AUTH_SHORT, AUTH_DH) per RFC 1831
- Create AuthSysCredential structure and parsing for AUTH_SYS credentials
- Implement authentication validation module (auth.go) with support for:
  * IP address restrictions (AllowedIPs) with CIDR notation support
  * Secure port requirement enforcement (port < 1024)
  * User ID squashing (root squashing and all-user squashing)
  * Multiple authentication flavors (AUTH_NONE and AUTH_SYS)

- Update HandleCall signature to accept AuthContext with client IP/port info
- Pass client connection information from server to authentication handler
- Replace overly restrictive auth check (rejected all but AUTH_NONE) with comprehensive validation that properly handles both AUTH_NONE and AUTH_SYS
- Integrate authentication failure tracking with metrics system

- Add comprehensive test coverage for:
  * AUTH_NONE and AUTH_SYS credential handling
  * IP restriction enforcement
  * Secure port requirement
  * Root and all-user squashing
  * AUTH_SYS credential parsing
  * IP address validation with CIDR support

Security improvements:
- Enforce IP-based access control when AllowedIPs is configured
- Require privileged ports when Secure flag is enabled
- Apply user ID mapping (squashing) to prevent privilege escalation
- Validate credential structures to prevent DoS via malformed data
- Track authentication failures in metrics for monitoring

All existing tests pass, new authentication tests verify correct behavior.