### PR TITLE
Fix connection tracking race condition in server

### DIFF
--- a/connection_management_test.go
+++ b/connection_management_test.go
@@ -171,7 +171,7 @@ func TestIdleConnectionCleanup(t *testing.T) {
 	
 	// Set the connection's activity time to be in the past
 	server.connMutex.Lock()
-	server.activeConns[conn] = time.Now().Add(-100 * time.Millisecond)
+	server.activeConns[conn].lastActivity = time.Now().Add(-100 * time.Millisecond)
 	server.connMutex.Unlock()
 	
 	// Run idle connection cleanup
@@ -210,9 +210,9 @@ func TestCloseAllConnections(t *testing.T) {
 	
 	// Register connections directly
 	server.connMutex.Lock()
-	server.activeConns[conn1] = time.Now()
-	server.activeConns[conn2] = time.Now()
-	server.activeConns[conn3] = time.Now()
+	server.activeConns[conn1] = &connectionState{lastActivity: time.Now()}
+	server.activeConns[conn2] = &connectionState{lastActivity: time.Now()}
+	server.activeConns[conn3] = &connectionState{lastActivity: time.Now()}
 	server.connCount = 3
 	server.connMutex.Unlock()
 	


### PR DESCRIPTION
Multiple goroutines could attempt to unregister the same connection simultaneously, leading to incorrect connection counts, potential negative counter values, and connection limit bypass.

Changes:
- Introduced connectionState struct with sync.Once to ensure each connection is only unregistered once
- Modified unregisterConnection to use sync.Once.Do() for atomic one-time cleanup
- Updated cleanupIdleConnections and closeAllConnections to call unregisterConnection instead of manually manipulating the map
- This ensures all unregistration goes through the same protected path
- Updated tests to work with new connectionState structure

The sync.Once mechanism guarantees that even if multiple goroutines (e.g., connection handler, idle cleanup, shutdown) try to unregister the same connection, the cleanup happens exactly once, preventing race conditions and maintaining accurate connection counts.

Fixes #14 