### PR TITLE
Implement symlinks support

### DIFF
--- a/mount_handlers_test.go
+++ b/mount_handlers_test.go
@@ -225,6 +225,11 @@ func TestHandleMountCall(t *testing.T) {
 		path := "/nonexistent"
 		binary.Write(&buf, binary.BigEndian, uint32(len(path)))
 		buf.WriteString(path)
+		// Add XDR padding
+		padding := (4 - (len(path) % 4)) % 4
+		if padding > 0 {
+			buf.Write(make([]byte, padding))
+		}
 
 		authCtx := &AuthContext{ClientIP: "127.0.0.1", ClientPort: 12345}
 		result, err := handler.handleMountCall(call, bytes.NewReader(buf.Bytes()), reply, authCtx)
@@ -353,6 +358,11 @@ func TestHandleMountCall(t *testing.T) {
 		path := "/"
 		binary.Write(&buf, binary.BigEndian, uint32(len(path)))
 		buf.WriteString(path)
+		// Add XDR padding
+		padding := (4 - (len(path) % 4)) % 4
+		if padding > 0 {
+			buf.Write(make([]byte, padding))
+		}
 
 		authCtx := &AuthContext{ClientIP: "127.0.0.1", ClientPort: 12345}
 		result, err := handler.handleMountCall(call, bytes.NewReader(buf.Bytes()), reply, authCtx)
@@ -499,6 +509,11 @@ func TestHandleMountCall(t *testing.T) {
 		path := "/"
 		binary.Write(&buf, binary.BigEndian, uint32(len(path)))
 		buf.WriteString(path)
+		// Add XDR padding
+		padding := (4 - (len(path) % 4)) % 4
+		if padding > 0 {
+			buf.Write(make([]byte, padding))
+		}
 
 		authCtx := &AuthContext{ClientIP: "127.0.0.1", ClientPort: 12345}
 		result, err := handler.handleMountCall(call, bytes.NewReader(buf.Bytes()), reply, authCtx)

--- a/nfs_operations_test.go
+++ b/nfs_operations_test.go
@@ -3,6 +3,7 @@ package absnfs
 import (
 	"bytes"
 	"encoding/binary"
+	"os"
 	"testing"
 
 	"github.com/absfs/memfs"
@@ -502,7 +503,12 @@ func TestNFSOperationsErrors(t *testing.T) {
 		filename := "newfile.txt"
 		binary.Write(&buf, binary.BigEndian, uint32(len(filename)))
 		buf.WriteString(filename)
-		
+		// Add XDR padding
+		padding := (4 - (len(filename) % 4)) % 4
+		if padding > 0 {
+			buf.Write(make([]byte, padding))
+		}
+
 		// Create mode and attributes
 		binary.Write(&buf, binary.BigEndian, uint32(0)) // Create mode
 		binary.Write(&buf, binary.BigEndian, uint32(0644)) // Mode
@@ -549,7 +555,12 @@ func TestNFSOperationsErrors(t *testing.T) {
 		filename = "invalidmode.txt"
 		binary.Write(&buf, binary.BigEndian, uint32(len(filename)))
 		buf.WriteString(filename)
-		
+		// Add XDR padding
+		padding = (4 - (len(filename) % 4)) % 4
+		if padding > 0 {
+			buf.Write(make([]byte, padding))
+		}
+
 		// Create mode and invalid attributes
 		binary.Write(&buf, binary.BigEndian, uint32(0)) // Create mode
 		binary.Write(&buf, binary.BigEndian, uint32(0x8000)) // Invalid mode
@@ -623,7 +634,12 @@ func TestNFSOperationsErrors(t *testing.T) {
 		dirname := "newdir"
 		binary.Write(&buf, binary.BigEndian, uint32(len(dirname)))
 		buf.WriteString(dirname)
-		
+		// Add XDR padding
+		padding := (4 - (len(dirname) % 4)) % 4
+		if padding > 0 {
+			buf.Write(make([]byte, padding))
+		}
+
 		// Mode
 		binary.Write(&buf, binary.BigEndian, uint32(0755)) // Directory mode
 
@@ -672,7 +688,12 @@ func TestNFSOperationsErrors(t *testing.T) {
 		dirname = "invalidmode"
 		binary.Write(&buf, binary.BigEndian, uint32(len(dirname)))
 		buf.WriteString(dirname)
-		
+		// Add XDR padding
+		padding = (4 - (len(dirname) % 4)) % 4
+		if padding > 0 {
+			buf.Write(make([]byte, padding))
+		}
+
 		// Invalid mode
 		binary.Write(&buf, binary.BigEndian, uint32(0x8000)) // Invalid mode
 
@@ -692,6 +713,286 @@ func TestNFSOperationsErrors(t *testing.T) {
 			}
 			if status != NFSERR_INVAL {
 				t.Errorf("Expected NFSERR_INVAL in reply data, got %v", status)
+			}
+		}
+	})
+
+	t.Run("NFSPROC3_SYMLINK operation", func(t *testing.T) {
+		server, err := newTestServer()
+		if err != nil {
+			t.Fatalf("Failed to create test server: %v", err)
+		}
+
+		// Get directory handle
+		dirNode, err := server.handler.Lookup("/testdir")
+		if err != nil {
+			t.Fatalf("Failed to lookup test directory: %v", err)
+		}
+		dirHandle := server.handler.fileMap.Allocate(dirNode)
+
+		handler := &NFSProcedureHandler{
+			server: server,
+		}
+
+		call := &RPCCall{
+			Header: RPCMsgHeader{
+				Xid:        1,
+				MsgType:    RPC_CALL,
+				RPCVersion: 2,
+				Program:    NFS_PROGRAM,
+				Version:    NFS_V3,
+				Procedure:  NFSPROC3_SYMLINK,
+			},
+			Credential: RPCCredential{
+				Flavor: 0,
+				Body:   []byte{},
+			},
+			Verifier: RPCVerifier{
+				Flavor: 0,
+				Body:   []byte{},
+			},
+		}
+
+		reply := &RPCReply{
+			Header: call.Header,
+			Status: MSG_ACCEPTED,
+		}
+
+		// Test successful symlink operation
+		var buf bytes.Buffer
+		binary.Write(&buf, binary.BigEndian, dirHandle)
+
+		// Write symlink name
+		symlinkName := "testlink"
+		binary.Write(&buf, binary.BigEndian, uint32(len(symlinkName)))
+		buf.WriteString(symlinkName)
+		// Add XDR padding
+		padding := (4 - (len(symlinkName) % 4)) % 4
+		if padding > 0 {
+			buf.Write(make([]byte, padding))
+		}
+
+		// Mode (for symlinks, typically 0777)
+		binary.Write(&buf, binary.BigEndian, uint32(0777))
+
+		// Write target path
+		target := "/testfile.txt"
+		binary.Write(&buf, binary.BigEndian, uint32(len(target)))
+		buf.WriteString(target)
+		// Add XDR padding
+		padding = (4 - (len(target) % 4)) % 4
+		if padding > 0 {
+			buf.Write(make([]byte, padding))
+		}
+
+		authCtx := &AuthContext{ClientIP: "127.0.0.1", ClientPort: 12345}
+		result, err := handler.handleNFSCall(call, bytes.NewReader(buf.Bytes()), reply, authCtx)
+		if err != nil {
+			t.Fatalf("handleNFSCall failed: %v", err)
+		}
+		if result.Status != MSG_ACCEPTED {
+			t.Errorf("Expected MSG_ACCEPTED status, got %v", result.Status)
+		}
+
+		// Verify status in reply data
+		if result.Data != nil {
+			data := result.Data.([]byte)
+			r := bytes.NewReader(data)
+			var status uint32
+			if err := binary.Read(r, binary.BigEndian, &status); err != nil {
+				t.Fatalf("Failed to read status from reply data: %v", err)
+			}
+			if status != NFS_OK {
+				t.Errorf("Expected NFS_OK in reply data, got %v", status)
+			}
+		}
+
+		// Verify symlink was created
+		symlinkFS, ok := server.handler.fs.(SymlinkFileSystem)
+		if !ok {
+			t.Skip("Filesystem does not support symlinks")
+		}
+		info, err := symlinkFS.Lstat("/testdir/testlink")
+		if err != nil {
+			t.Errorf("Symlink was not created: %v", err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Errorf("Created path is not a symlink")
+		}
+
+		// Test with empty target (should fail)
+		buf.Reset()
+		binary.Write(&buf, binary.BigEndian, dirHandle)
+
+		symlinkName = "badlink"
+		binary.Write(&buf, binary.BigEndian, uint32(len(symlinkName)))
+		buf.WriteString(symlinkName)
+		// Add XDR padding
+		padding = (4 - (len(symlinkName) % 4)) % 4
+		if padding > 0 {
+			buf.Write(make([]byte, padding))
+		}
+
+		binary.Write(&buf, binary.BigEndian, uint32(0777))
+
+		// Empty target
+		binary.Write(&buf, binary.BigEndian, uint32(0))
+
+		authCtx = &AuthContext{ClientIP: "127.0.0.1", ClientPort: 12345}
+		result, err = handler.handleNFSCall(call, bytes.NewReader(buf.Bytes()), reply, authCtx)
+		if err != nil {
+			t.Fatalf("handleNFSCall failed: %v", err)
+		}
+
+		// Verify error status in reply data
+		if result.Data != nil {
+			data := result.Data.([]byte)
+			r := bytes.NewReader(data)
+			var status uint32
+			if err := binary.Read(r, binary.BigEndian, &status); err != nil {
+				t.Fatalf("Failed to read status from reply data: %v", err)
+			}
+			if status != NFSERR_INVAL {
+				t.Errorf("Expected NFSERR_INVAL for empty target, got %v", status)
+			}
+		}
+	})
+
+	t.Run("NFSPROC3_READLINK operation", func(t *testing.T) {
+		server, err := newTestServer()
+		if err != nil {
+			t.Fatalf("Failed to create test server: %v", err)
+		}
+
+		// Create a symlink
+		target := "/testfile.txt"
+		symlinkFS, ok := server.handler.fs.(SymlinkFileSystem)
+		if !ok {
+			t.Skip("Filesystem does not support symlinks")
+		}
+		err = symlinkFS.Symlink(target, "/testdir/linktofile")
+		if err != nil {
+			t.Fatalf("Failed to create symlink: %v", err)
+		}
+
+		// Get symlink handle
+		symlinkNode, err := server.handler.Lookup("/testdir/linktofile")
+		if err != nil {
+			t.Fatalf("Failed to lookup symlink: %v", err)
+		}
+		symlinkHandle := server.handler.fileMap.Allocate(symlinkNode)
+
+		handler := &NFSProcedureHandler{
+			server: server,
+		}
+
+		call := &RPCCall{
+			Header: RPCMsgHeader{
+				Xid:        1,
+				MsgType:    RPC_CALL,
+				RPCVersion: 2,
+				Program:    NFS_PROGRAM,
+				Version:    NFS_V3,
+				Procedure:  NFSPROC3_READLINK,
+			},
+			Credential: RPCCredential{
+				Flavor: 0,
+				Body:   []byte{},
+			},
+			Verifier: RPCVerifier{
+				Flavor: 0,
+				Body:   []byte{},
+			},
+		}
+
+		reply := &RPCReply{
+			Header: call.Header,
+			Status: MSG_ACCEPTED,
+		}
+
+		// Test successful readlink operation
+		var buf bytes.Buffer
+		binary.Write(&buf, binary.BigEndian, symlinkHandle)
+
+		authCtx := &AuthContext{ClientIP: "127.0.0.1", ClientPort: 12345}
+		result, err := handler.handleNFSCall(call, bytes.NewReader(buf.Bytes()), reply, authCtx)
+		if err != nil {
+			t.Fatalf("handleNFSCall failed: %v", err)
+		}
+		if result.Status != MSG_ACCEPTED {
+			t.Errorf("Expected MSG_ACCEPTED status, got %v", result.Status)
+		}
+
+		// Verify status in reply data
+		if result.Data != nil {
+			data := result.Data.([]byte)
+			r := bytes.NewReader(data)
+			var status uint32
+			if err := binary.Read(r, binary.BigEndian, &status); err != nil {
+				t.Fatalf("Failed to read status from reply data: %v", err)
+			}
+			if status != NFS_OK {
+				t.Errorf("Expected NFS_OK in reply data, got %v", status)
+			}
+
+			// Skip post-op attributes flag and attributes
+			var hasAttrs uint32
+			if err := binary.Read(r, binary.BigEndian, &hasAttrs); err != nil {
+				t.Fatalf("Failed to read hasAttrs: %v", err)
+			}
+
+			if hasAttrs == 1 {
+				// Skip file attributes: mode, nlink, uid, gid (4 bytes each) + size, mtime, atime (8 bytes each)
+				// Total: 4*4 + 8*3 = 40 bytes
+				attrBuf := make([]byte, 40)
+				if _, err := r.Read(attrBuf); err != nil {
+					t.Fatalf("Failed to read attributes: %v", err)
+				}
+			}
+
+			// Read target path length and value
+			var targetLen uint32
+			if err := binary.Read(r, binary.BigEndian, &targetLen); err != nil {
+				t.Fatalf("Failed to read target length: %v", err)
+			}
+
+			targetBytes := make([]byte, targetLen)
+			if _, err := r.Read(targetBytes); err != nil {
+				t.Fatalf("Failed to read target: %v", err)
+			}
+
+			readTarget := string(targetBytes)
+			if readTarget != target {
+				t.Errorf("Expected target %s, got %s", target, readTarget)
+			}
+		}
+
+		// Test readlink on non-symlink (should fail)
+		fileNode, err := server.handler.Lookup("/testfile.txt")
+		if err != nil {
+			t.Fatalf("Failed to lookup test file: %v", err)
+		}
+		fileHandle := server.handler.fileMap.Allocate(fileNode)
+
+		buf.Reset()
+		binary.Write(&buf, binary.BigEndian, fileHandle)
+
+		authCtx = &AuthContext{ClientIP: "127.0.0.1", ClientPort: 12345}
+		result, err = handler.handleNFSCall(call, bytes.NewReader(buf.Bytes()), reply, authCtx)
+		if err != nil {
+			t.Fatalf("handleNFSCall failed: %v", err)
+		}
+
+		// Verify error status in reply data
+		if result.Data != nil {
+			data := result.Data.([]byte)
+			r := bytes.NewReader(data)
+			var status uint32
+			if err := binary.Read(r, binary.BigEndian, &status); err != nil {
+				t.Fatalf("Failed to read status from reply data: %v", err)
+			}
+			if status != NFSERR_INVAL {
+				t.Errorf("Expected NFSERR_INVAL for non-symlink, got %v", status)
 			}
 		}
 	})

--- a/types.go
+++ b/types.go
@@ -13,6 +13,13 @@ import (
 // Version represents the current version of the absnfs package
 const Version = "0.1.0"
 
+// SymlinkFileSystem represents a filesystem that supports symbolic links
+type SymlinkFileSystem interface {
+	Symlink(oldname, newname string) error
+	Readlink(name string) (string, error)
+	Lstat(name string) (os.FileInfo, error)
+}
+
 // AbsfsNFS represents an NFS server that exports an absfs filesystem
 type AbsfsNFS struct {
 	fs            absfs.FileSystem  // The wrapped absfs filesystem


### PR DESCRIPTION
Add full support for symbolic links in the NFS server implementation:

- Implement NFSPROC3_SYMLINK handler for creating symbolic links
- Implement NFSPROC3_READLINK handler for reading symbolic link targets
- Add SymlinkFileSystem interface for filesystems supporting symlinks
- Update Lookup and GetAttr operations to use Lstat for proper symlink handling
- Add comprehensive tests for both SYMLINK and READLINK operations

Fix XDR string encoding to include proper padding:
- Update xdrEncodeString to add 4-byte alignment padding
- Update xdrDecodeString to skip padding bytes
- Update all tests to use proper XDR padding for string parameters

This implementation allows NFS clients to create and read symbolic links on filesystems that support them (e.g., memfs), while gracefully handling filesystems that don't support symlinks through type assertions.